### PR TITLE
Use Services global variable

### DIFF
--- a/addon/apis/compose_ext/implementation.js
+++ b/addon/apis/compose_ext/implementation.js
@@ -3,9 +3,6 @@
 // Get various parts of the WebExtension framework that we need.
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 
-// You probably already know what this does.
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // Compare semver versions 'x.y.z' (only numbers)
 function compareVersion(v1, v2) {
   if (typeof v1 !== 'string') return false;


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 102.