### PR TITLE
feat!: remove Thunderbird support for < 128

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -3,7 +3,7 @@
   "applications": {
     "gecko": {
       "id": "automatic_dictionary_extension@jordi_beltran.net",
-      "strict_min_version": "102.0",
+      "strict_min_version": "128.0",
       "strict_max_version": "136.0"
     }
   },


### PR DESCRIPTION
Latest thunderbird requires changes that break compatibility with older versions like the `ChromeUtils.importESModule`

Fixes #318 