### PR TITLE
chore: Fix CI after debian new version and Thunderbird changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Container to run functional tests of the extension.
-FROM ruby:3.4.5 as base
+FROM ruby:3.4.5 AS base
 
 # Configure locale as utf to avoid encoding issues
 RUN apt-get update && apt-get install -y sudo
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
-ENV APP_HOME /app
+ENV APP_HOME=/app
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 

--- a/script/install_dependencies.sh
+++ b/script/install_dependencies.sh
@@ -6,21 +6,14 @@ sudo apt-get update
 sudo apt-get install -y xvfb zip unzip fluxbox xserver-xephyr curl \
  imagemagick libmagickwand-dev xvfb unzip xdotool
 
-# Tesseract 5
-sudo apt-get install -y apt-transport-https lsb-release
-echo "deb https://notesalexp.org/tesseract-ocr5/$(lsb_release -cs)/ $(lsb_release -cs) main" \
-| sudo tee /etc/apt/sources.list.d/notesalexp.list > /dev/null
-sudo apt-get update -oAcquire::AllowInsecureRepositories=true
-sudo apt-get install -y --allow-unauthenticated notesalexp-keyring -oAcquire::AllowInsecureRepositories=true
-sudo apt-get update
-sudo apt-get install -y tesseract-ocr --allow-unauthenticated
+# Install Tesseract OCR from default repositories
+sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
 
 sudo apt-get install -y git-core curl zlib1g-dev build-essential libssl-dev \
   libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev \
   libcurl4-openssl-dev libffi-dev dbus-x11
 
 # Install thunderbird dependencies
-sudo apt-get install -y software-properties-common
 apt-get install -y `apt-cache depends thunderbird | awk '/Depends:/{print$2}'`
 
 PREV_PATH=$(pwd)

--- a/script/install_thunderbird.sh
+++ b/script/install_thunderbird.sh
@@ -10,8 +10,15 @@ if [ "$THUNDERBIRD_VERSION" == "esr" ]; then
 fi
 
 # URL returns the right file for "beta-latest" or "latest", or even a specific version "78.11.0"
+# Note: Mozilla now uses .tar.xz format instead of .tar.bz2
 PACKAGE_URL="https://download.mozilla.org/?product=thunderbird-${THUNDERBIRD_VERSION}-SSL&os=linux64&lang=en-US"
 
-curl -L $PACKAGE_URL -o thunderbird.tar.bz2
-tar -xvf thunderbird.tar.bz2 -C /tmp/
+# Install xz-utils for extracting .tar.xz files
+sudo apt-get update && sudo apt-get install -y xz-utils
+
+DOWNLOAD_DIR="/tmp/thunderbird-download"
+mkdir -p $DOWNLOAD_DIR
+cd $DOWNLOAD_DIR
+wget --content-disposition $PACKAGE_URL
+tar -xvf /tmp/thunderbird-download/* -C /tmp/
 echo "export PATH=/tmp/thunderbird/:\$PATH" >> ~/.bash_profile

--- a/test/integration/spec/automatic_dictionary/integration_spec.rb
+++ b/test/integration/spec/automatic_dictionary/integration_spec.rb
@@ -13,7 +13,7 @@ describe "AutomaticDictionary integration tests" do
   # - It deduces langauge based on domain.
   # - Preferences window shows correctly.
 
-  INSTALLED_DICTIONARIES = %w[Spanish English].freeze
+  INSTALLED_DICTIONARIES = ["Spanish", "English (United States)"].freeze
 
   let(:profile_path) { Dir.mktmpdir }
   let(:logger) do


### PR DESCRIPTION
Changes:
- Adapted Dockerfile and dependencies to Debian Dixie.
- Thunderbird downloads now use .tar.xz
- Thunderbird bin now comes with Canadian English dictionary installed.